### PR TITLE
Rebuild main site as a Markdown-driven static CV

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment, cancelling in-progress runs for the same ref.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install games dependencies
+        run: npm ci --prefix web-ui
+
+      - name: Build site (games + CV)
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
+node_modules
 */node_modules
 /.pnp
 .pnp.js
@@ -10,6 +11,7 @@
 
 # production
 */build
+/dist
 
 # misc
 .DS_Store

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+harleyadams.dev

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # harley-adams.github.io
+
+Personal site for Harley Adams, hosted at **[harleyadams.dev](https://harleyadams.dev)**.
+
+It is a single-page, print-friendly CV generated from one Markdown file, plus a small
+collection of React games served under `/games/`.
+
+## Layout
+
+```
+cv.md                 # single source of truth for the CV content
+posts/                # Markdown blog posts ("Thoughts")
+src/                  # HTML shells + styles (CV / post / thoughts list)
+build.mjs             # static-site generator: cv.md + posts/ -> dist/, copies games
+scripts/preview.mjs   # local static server that emulates GitHub Pages 404 handling
+web-ui/               # existing Create React App games (unchanged logic)
+dist/                 # build output (git-ignored)
+```
+
+Build output (`dist/`):
+
+| Path           | Contents                                            |
+| -------------- | --------------------------------------------------- |
+| `/index.html`  | The CV (static HTML, inlined CSS, prints to PDF)     |
+| `/thoughts/`   | Blog index + posts                                  |
+| `/games/`      | React games (copied from `web-ui/build`)            |
+| `/404.html`    | SPA redirect so `/games/...` deep links round-trip  |
+| `/CNAME`       | Custom domain                                       |
+
+## Develop
+
+Edit the CV by editing **`cv.md`**. Add a blog post by dropping a Markdown file in
+**`posts/`** (front-matter `title`, `date`, optional `draft: true`).
+
+```bash
+npm install                 # install generator deps (gray-matter, markdown-it)
+npm run build:cv            # build only the CV + thoughts (fast)
+npm run build               # full build: games + CV -> dist/
+npm run preview             # serve dist/ at http://localhost:4178
+```
+
+`npm run build` runs the games build with `CI=false` so pre-existing CRA lint warnings
+do not fail the build.
+
+To preview the print/PDF output, open the CV and use your browser's Print (⌘P / Ctrl-P).
+
+## Games
+
+The React games live in `web-ui/` and are served under `/games/`. Their app logic is
+unchanged; only deployment config is set for the subpath:
+
+- `web-ui/package.json` → `"homepage": "/games"`
+- `web-ui/src/index.tsx` → router `basename: "/games"`
+- `web-ui/public/404.html` → `pathSegmentsToKeep = 1`
+
+## Deploy
+
+Pushing to `main` triggers `.github/workflows/deploy.yml`, which builds the full `dist/`
+and publishes it to GitHub Pages.
+
+> **One-time setup:** in the repo's **Settings → Pages**, set **Source** to
+> **GitHub Actions**. (The site previously deployed from the `gh-pages` branch via the
+> `gh-pages` npm package; this workflow replaces that flow.)

--- a/build.mjs
+++ b/build.mjs
@@ -1,0 +1,386 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import matter from 'gray-matter';
+import MarkdownIt from 'markdown-it';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = path.join(root, 'src');
+const outDir = path.join(root, 'dist');
+const gamesBuildDir = path.join(root, 'web-ui', 'build');
+
+const BRAND = 'Harley Adams';
+
+const md = new MarkdownIt({ html: true, linkify: false, typographer: false });
+
+// Render ```mermaid fences as <pre class="mermaid"> so they render client-side.
+const defaultFence = md.renderer.rules.fence.bind(md.renderer.rules);
+md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+  const info = (tokens[idx].info || '').trim();
+  if (info === 'mermaid') {
+    return `<pre class="mermaid">${escapeHtml(tokens[idx].content)}</pre>\n`;
+  }
+  return defaultFence(tokens, idx, options, env, self);
+};
+
+// Small inline icons (fill follows currentColor).
+const icons = {
+  location:
+    '<svg class="ico" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M12 2a7 7 0 0 0-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 0 0-7-7Zm0 9.5A2.5 2.5 0 1 1 12 6.5a2.5 2.5 0 0 1 0 5Z"/></svg>',
+  email:
+    '<svg class="ico" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm1.4 2L12 12.2 19.6 7H4.4ZM20 8.6l-7.4 5.05a1 1 0 0 1-1.2 0L4 8.6V17h16V8.6Z"/></svg>',
+  LinkedIn:
+    '<svg class="ico" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M4.98 3.5A2.5 2.5 0 1 0 5 8.5a2.5 2.5 0 0 0-.02-5ZM3 9h4v12H3V9Zm6 0h3.8v1.7h.05c.53-.95 1.83-1.95 3.77-1.95 4.03 0 4.78 2.65 4.78 6.1V21h-4v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21H9V9Z"/></svg>',
+  GitHub:
+    '<svg class="ico" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.53 2.36 1.09 2.94.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.6 9.6 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.69-4.57 4.94.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 22 12 10 10 0 0 0 12 2Z"/></svg>',
+};
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function handleFromUrl(label, url) {
+  try {
+    const u = new URL(url);
+    const p = u.pathname.replace(/^\/+|\/+$/g, '');
+    if (label === 'GitHub') return '@' + (p.split('/').pop() || u.hostname);
+    return p || u.hostname;
+  } catch (_) {
+    return url;
+  }
+}
+
+function collectLinks(data) {
+  const links = [];
+  if (data.linkedin)
+    links.push({ label: 'LinkedIn', url: data.linkedin, handle: handleFromUrl('LinkedIn', data.linkedin) });
+  if (data.github)
+    links.push({ label: 'GitHub', url: data.github, handle: handleFromUrl('GitHub', data.github) });
+  if (Array.isArray(data.links)) {
+    for (const l of data.links)
+      links.push({ label: l.label, url: l.url, handle: l.handle || handleFromUrl(l.label, l.url) });
+  }
+  return links;
+}
+
+function buildContact(data) {
+  const items = [];
+  if (data.location) {
+    items.push(`<li>${icons.location}<span>${escapeHtml(data.location)}</span></li>`);
+  }
+  if (data.email) {
+    const [user, domain] = String(data.email).split('@');
+    const b64 = Buffer.from(String(data.email)).toString('base64');
+    const fallback = `${escapeHtml(user)} [at] ${escapeHtml(domain)}`;
+    items.push(
+      `<li>${icons.email}<span class="cv-email" data-e="${b64}">${fallback}</span></li>`
+    );
+  }
+  for (const link of collectLinks(data)) {
+    const icon = icons[link.label] || '';
+    const text = escapeHtml(link.handle || link.label);
+    items.push(
+      `<li>${icon}<a href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer">${text}</a></li>`
+    );
+  }
+  return items.join('\n      ');
+}
+
+const emailScript = `<script>
+  (function () {
+    var el = document.querySelector('.cv-email');
+    if (!el) return;
+    try {
+      var e = atob(el.getAttribute('data-e'));
+      var a = document.createElement('a');
+      a.href = 'mailto:' + e;
+      a.textContent = e;
+      el.replaceChildren(a);
+    } catch (_) {}
+  })();
+</script>`;
+
+function nav(base, active) {
+  const cur = (k) => (active === k ? ' aria-current="page"' : '');
+  const brand =
+    active === 'cv'
+      ? ''
+      : `<a class="site-nav-brand" href="${base}index.html">${escapeHtml(BRAND)}</a>`;
+  return `<nav class="site-nav" aria-label="Primary">
+      <div class="site-nav-inner">
+        ${brand}
+        <div class="site-nav-links">
+          <a href="${base}index.html"${cur('cv')}>CV</a>
+          <a href="${base}games/index.html"${cur('games')}>Games</a>
+          <a href="${base}thoughts/index.html"${cur('thoughts')}>Thoughts</a>
+        </div>
+      </div>
+    </nav>`;
+}
+
+function formatDate(d) {
+  const date = d instanceof Date ? d : new Date(d);
+  if (Number.isNaN(date.getTime())) return { iso: '', human: String(d ?? '') };
+  return {
+    iso: date.toISOString().slice(0, 10),
+    human: String(date.getUTCFullYear()),
+  };
+}
+
+function renderTags(tags) {
+  if (!Array.isArray(tags) || tags.length === 0) return '';
+  const chips = tags.map((t) => `<span class="tag">${escapeHtml(t)}</span>`).join('');
+  return `<span class="post-tags">${chips}</span>`;
+}
+
+// Read intrinsic PNG dimensions from the IHDR chunk (no dependencies).
+function pngSize(file) {
+  try {
+    const buf = fs.readFileSync(file);
+    if (buf.length > 24 && buf.toString('ascii', 12, 16) === 'IHDR') {
+      return { w: buf.readUInt32BE(16), h: buf.readUInt32BE(20) };
+    }
+  } catch (_) {}
+  return null;
+}
+
+function renderCover(data, slug, postsDir) {
+  if (!data.cover) return '';
+  const alt = escapeHtml(data.coverAlt || data.title || '');
+  const dim = pngSize(path.join(postsDir, slug, data.cover));
+  const size = dim ? ` width="${dim.w}" height="${dim.h}"` : '';
+  return `<figure class="post-cover">
+          <img src="${escapeHtml(data.cover)}" alt="${alt}"${size} loading="eager" decoding="async" />
+        </figure>`;
+}
+
+// Copy a post's sibling asset folder (posts/<slug>/) into its output dir.
+function copyPostAssets(postsDir, slug, destDir) {
+  const assetDir = path.join(postsDir, slug);
+  if (!fs.existsSync(assetDir) || !fs.statSync(assetDir).isDirectory()) return;
+  for (const f of fs.readdirSync(assetDir)) {
+    const src = path.join(assetDir, f);
+    if (fs.statSync(src).isFile()) fs.copyFileSync(src, path.join(destDir, f));
+  }
+}
+
+function renderSocial(data, slug, siteUrl) {
+  if (data.cover && siteUrl) {
+    const url = escapeHtml(`${siteUrl}/thoughts/${slug}/${data.cover}`);
+    return `<meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:image" content="${url}" />
+    <meta name="twitter:image" content="${url}" />`;
+  }
+  return '<meta name="twitter:card" content="summary" />';
+}
+
+const mermaidScript = `<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'loose' });
+  await mermaid.run({ querySelector: 'pre.mermaid' });
+</script>`;
+
+function rightAlignDates(html) {
+  const sep = ' \u00b7 ';
+  return html.replace(/<(h3|h4)>([\s\S]*?)<\/\1>/g, (m, tag, inner) => {
+    const idx = inner.lastIndexOf(sep);
+    if (idx === -1) return m;
+    const last = inner.slice(idx + sep.length).trim();
+    if (!/(?:19|20)\d{2}|present/i.test(last)) return m;
+    const left = inner.slice(0, idx);
+    return `<${tag} class="entry"><span class="entry-title">${left}</span><span class="entry-date">${last}</span></${tag}>`;
+  });
+}
+
+function buildCV(styles) {
+  const raw = fs.readFileSync(path.join(root, 'cv.md'), 'utf8');
+  const { data, content } = matter(raw);
+
+  let bodyHtml = md.render(content);
+  // Standalone emphasised lines (e.g. "*2017 - Present*") become muted meta lines.
+  bodyHtml = bodyHtml.replace(/<p><em>([\s\S]*?)<\/em><\/p>/g, '<p class="meta">$1</p>');
+  // Pull a trailing " · <date>" out of entry headings and right-align it.
+  bodyHtml = rightAlignDates(bodyHtml);
+
+  const template = fs.readFileSync(path.join(srcDir, 'template.html'), 'utf8');
+
+  const html = template
+    .replaceAll('{{TITLE_TAG}}', `${escapeHtml(data.name)} \u00b7 ${escapeHtml(data.title)}`)
+    .replaceAll('{{DESCRIPTION}}', escapeHtml(data.tagline || ''))
+    .replaceAll('{{NAME}}', escapeHtml(data.name))
+    .replaceAll('{{TITLE}}', escapeHtml(data.title))
+    .replaceAll('{{TAGLINE}}', escapeHtml(data.tagline || ''))
+    .replaceAll('{{CONTACT}}', buildContact(data))
+    .replaceAll('{{NAV}}', nav('', 'cv'))
+    .replaceAll('{{STYLES}}', styles)
+    .replaceAll('{{CONTENT}}', bodyHtml)
+    .replaceAll('{{SCRIPTS}}', emailScript);
+
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'index.html'), html, 'utf8');
+  console.log('Built dist/index.html');
+}
+
+function buildThoughts(styles, siteUrl) {
+  const postsDir = path.join(root, 'posts');
+  if (!fs.existsSync(postsDir)) return;
+
+  const postTemplate = fs.readFileSync(path.join(srcDir, 'post.html'), 'utf8');
+  const thoughtsTemplate = fs.readFileSync(path.join(srcDir, 'thoughts.html'), 'utf8');
+
+  const posts = [];
+  for (const file of fs.readdirSync(postsDir)) {
+    if (!file.endsWith('.md')) continue;
+    const raw = fs.readFileSync(path.join(postsDir, file), 'utf8');
+    const { data, content } = matter(raw);
+    if (data.draft) continue;
+    const slug = path.basename(file, '.md');
+    const { iso, human } = formatDate(data.date);
+    const sortKey = data.date ? new Date(data.date).getTime() : 0;
+    posts.push({ slug, data, content, iso, human, sortKey });
+  }
+  posts.sort((a, b) => b.sortKey - a.sortKey);
+
+  const base = '../../';
+  for (const post of posts) {
+    const bodyHtml = md.render(post.content);
+    const hasMermaid = bodyHtml.includes('class="mermaid"');
+    const canonical = siteUrl
+      ? `${siteUrl}/thoughts/${post.slug}/`
+      : `thoughts/${post.slug}/`;
+
+    const html = postTemplate
+      .replaceAll('{{TITLE_TAG}}', `${escapeHtml(post.data.title)} \u00b7 ${escapeHtml(BRAND)}`)
+      .replaceAll('{{DESCRIPTION}}', escapeHtml(post.data.summary || ''))
+      .replaceAll('{{CANONICAL}}', escapeHtml(canonical))
+      .replaceAll('{{OG_TITLE}}', escapeHtml(post.data.title))
+      .replaceAll('{{SOCIAL}}', renderSocial(post.data, post.slug, siteUrl))
+      .replaceAll('{{THOUGHTS_HREF}}', `${base}thoughts/index.html`)
+      .replaceAll('{{NAV}}', nav(base, 'thoughts'))
+      .replaceAll('{{STYLES}}', styles)
+      .replaceAll('{{TITLE}}', escapeHtml(post.data.title))
+      .replaceAll('{{DATE_ISO}}', post.iso)
+      .replaceAll('{{DATE_HUMAN}}', escapeHtml(post.human))
+      .replaceAll('{{TAGS}}', renderTags(post.data.tags))
+      .replaceAll('{{COVER}}', renderCover(post.data, post.slug, postsDir))
+      .replaceAll('{{CONTENT}}', bodyHtml)
+      .replaceAll('{{SCRIPTS}}', hasMermaid ? mermaidScript : '');
+
+    const dir = path.join(outDir, 'thoughts', post.slug);
+    fs.mkdirSync(dir, { recursive: true });
+    copyPostAssets(postsDir, post.slug, dir);
+    fs.writeFileSync(path.join(dir, 'index.html'), html, 'utf8');
+  }
+
+  const items = posts
+    .map((post) => {
+      const tags =
+        Array.isArray(post.data.tags) && post.data.tags.length
+          ? `\n          <div class="post-list-tags">${post.data.tags
+              .map((t) => `<span class="tag">${escapeHtml(t)}</span>`)
+              .join('')}</div>`
+          : '';
+      return `        <li class="post-list-item">
+          <p class="post-list-date"><time datetime="${post.iso}">${escapeHtml(post.human)}</time></p>
+          <h2 class="post-list-title"><a href="${post.slug}/index.html">${escapeHtml(post.data.title)}</a></h2>
+          <p class="post-list-summary">${escapeHtml(post.data.summary || '')}</p>${tags}
+        </li>`;
+    })
+    .join('\n');
+
+  const listHtml = thoughtsTemplate
+    .replaceAll('{{TITLE_TAG}}', `Thoughts \u00b7 ${escapeHtml(BRAND)}`)
+    .replaceAll('{{DESCRIPTION}}', 'Writing on software engineering, gaming cloud services, and side projects.')
+    .replaceAll('{{NAV}}', nav('../', 'thoughts'))
+    .replaceAll('{{STYLES}}', styles)
+    .replaceAll(
+      '{{LIST}}',
+      items || '        <li class="post-list-item"><p class="post-list-summary">Nothing here yet.</p></li>'
+    );
+
+  const dir = path.join(outDir, 'thoughts');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'index.html'), listHtml, 'utf8');
+  console.log(`Built dist/thoughts/ (${posts.length} post${posts.length === 1 ? '' : 's'})`);
+}
+
+// Recursively copy a directory (Node 16+ compatible).
+function copyDir(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDir(s, d);
+    else if (entry.isFile()) fs.copyFileSync(s, d);
+  }
+}
+
+// Copy the built React games app into dist/games/.
+function copyGames() {
+  if (!fs.existsSync(gamesBuildDir)) {
+    console.warn('Skipping games: web-ui/build not found. Run "npm run build:games" first.');
+    return;
+  }
+  const dest = path.join(outDir, 'games');
+  copyDir(gamesBuildDir, dest);
+  console.log('Copied web-ui/build -> dist/games/');
+}
+
+// Single-page-app 404 for GitHub Pages: deep links under /games/ are bounced into
+// the React app; any other unknown path falls back to the CV home.
+function writeRoot404() {
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting…</title>
+    <script>
+      (function () {
+        var l = window.location;
+        var p = l.pathname;
+        if (p.indexOf('/games/') === 0 && p !== '/games/') {
+          var rest = p.slice('/games/'.length).replace(/&/g, '~and~');
+          l.replace(
+            l.protocol + '//' + l.host + '/games/?/' + rest +
+            (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+            l.hash
+          );
+        } else {
+          l.replace(l.protocol + '//' + l.host + '/');
+        }
+      })();
+    </script>
+  </head>
+  <body></body>
+</html>
+`;
+  fs.writeFileSync(path.join(outDir, '404.html'), html, 'utf8');
+  console.log('Built dist/404.html');
+}
+
+function main() {
+  const styles = fs.readFileSync(path.join(srcDir, 'styles.css'), 'utf8');
+
+  let siteUrl = '';
+  const cnamePath = path.join(root, 'CNAME');
+  if (fs.existsSync(cnamePath)) {
+    const host = fs.readFileSync(cnamePath, 'utf8').trim();
+    if (host) siteUrl = `https://${host}`;
+  }
+
+  buildCV(styles);
+  buildThoughts(styles, siteUrl);
+  copyGames();
+  writeRoot404();
+
+  // Copy CNAME if present (for custom-domain GitHub Pages).
+  if (fs.existsSync(cnamePath)) {
+    fs.copyFileSync(cnamePath, path.join(outDir, 'CNAME'));
+  }
+}
+
+main();

--- a/cv.md
+++ b/cv.md
@@ -1,0 +1,72 @@
+---
+name: Harley Adams
+title: Senior Software Engineer · Tech Lead
+tagline: Xbox · PlayFab · Building gaming cloud services at Microsoft.
+github: https://github.com/Harley-Adams
+email: harley.g.adams@gmail.com
+linkedin: https://www.linkedin.com/in/harleyadams
+location: Redmond, WA
+---
+
+## Summary
+
+Software engineer with a decade of experience building and operating cloud services across gaming and productivity. Currently a tech lead for gaming cloud services on Xbox and PlayFab at Microsoft, where I design, ship, and maintain live-service platform features used across the Xbox Network. Comfortable across the stack in C#/.NET and TypeScript/React, with a focus on reliable, well-instrumented backend systems.
+
+## Experience
+
+### Architect, Xbox Developer Organization · 2025 – Present
+
+*Microsoft*
+
+- Lead the architecture for modernizing legacy Xbox Live services onto a cloud-native [AKS](https://azure.microsoft.com/products/kubernetes-service) stack, setting the technical direction for the wider organization.
+- Designing the next generation of Achievements — enriching the semantic meaning of an Achievement with AI-driven enhancements.
+
+### Tech Lead & Senior Software Engineer, Xbox / PlayFab · 2020 – 2025
+
+*Microsoft*
+
+- Tech lead for gaming cloud services across the Xbox Network ecosystem and Microsoft's [PlayFab](https://playfab.com/) offering.
+- Key engineer driving the design, delivery, and operation of the Achievements, Leaderboards, Stats, and Minutes Played services — owning architecture decisions and leading the implementation efforts end to end.
+
+### Software Engineer II, Microsoft Sway · 2016 – 2020
+
+*Microsoft*
+
+- Instrumental in making [Sway](https://sway.office.com/) accessible — from compliance through to a delightful experience for every user.
+- Assessed new feature work, and triaged and fixed publicly reported bug bounties to keep the Sway service safe and secure.
+- Designed and implemented the full stack for Sway Author Analytics, giving authors visibility into how their Sways are consumed: client-side tracking, endpoints for the Sway clients to post and fetch data, Azure Stream Analytics processing, and SQL storage.
+
+### Junior Software Engineer, Fiserv · 2015 – 2016
+
+*Auckland, New Zealand*
+
+- Wrote backend services in C# / .NET for mobile banking applications, along with the deployment pipelines for those services.
+
+## Projects
+
+### TotallyNotWordle — Battle Royale Edition
+
+- A Wordle-inspired puzzle game (after Josh Wardle's viral 2021 hit) with a multiplayer battle-royale mode: players join a lobby and race to guess the word first. Backed by "live service" features — stat tracking, leaderboards, and multiplayer — powered by PlayFab. Built with React, TypeScript, and Material UI. [Play it](/games/MultiplayerGames).
+
+### Run Box Run
+
+- An Android game published to the Google Play Store, written during university with no frameworks beyond built-in Java and Android APIs.
+
+## Skills
+
+- **Programming:** C# / .NET 8 · Python · JavaScript / TypeScript · PowerShell · Bash · Azure CLI
+- **Cloud & DevOps:** Azure Kubernetes Service · Cosmos DB · Event Hubs · Redis · Docker · Bicep · Terraform · Grafana · Prometheus · Locust · Azure Load Testing · PlayFab
+
+## Education
+
+### BSc, Computer Science · University of Auckland · 2012 – 2014
+
+*Auckland, New Zealand*
+
+- Worked as a Teaching Assistant for the Computer Science department, helping and teaching students with course material and assignments.
+
+## Press
+
+- **"The wizard at Xbox HQ"** — My first major project, surfacing time played across all Xbox titles, delighted millions of players and the community at [trueachievements.com](https://www.trueachievements.com/n45338/xbox-games-time-played).
+- **PlayFab Statistics — General Availability** — Launch announcement for the new Statistics and Leaderboards offering, now shipped in titles including Microsoft Flight Simulator 2024. [Read the announcement](https://developer.microsoft.com/en-us/games/articles/2025/03/new-playfab-statistics-general-availability).
+- **PlayFab Leaderboards — General Availability** — [Read the announcement](https://developer.microsoft.com/en-us/games/articles/2025/03/leverage-new-features-with-playfab-leaderboards/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,209 @@
+{
+  "name": "harley-adams.github.io",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "harley-adams.github.io",
+      "version": "1.0.0",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "markdown-it": "^14.1.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "harley-adams.github.io",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Personal site for Harley Adams: a one-page CV built from a single Markdown source, plus the React games served under /games.",
+  "scripts": {
+    "build:cv": "node build.mjs",
+    "build:games": "CI=false npm --prefix web-ui run build",
+    "build": "npm run build:games && npm run build:cv",
+    "preview": "node scripts/preview.mjs"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "markdown-it": "^14.1.0"
+  }
+}

--- a/posts/welcome.md
+++ b/posts/welcome.md
@@ -1,0 +1,18 @@
+---
+title: "Welcome to the new site"
+date: 2026-06-22
+draft: false
+summary: "A quick note on rebuilding harleyadams.dev as a single-page, print-friendly CV — and where the games went."
+tags:
+  - meta
+---
+
+I rebuilt harleyadams.dev around a single Markdown file. The whole CV is now generated
+from [`cv.md`](https://github.com/Harley-Adams/harley-adams.github.io/blob/main/cv.md) into
+one self-contained page that prints cleanly to PDF — just hit **Print → Save as PDF**.
+
+The interactive projects (my Wordle clones and friends) still live here too — they moved
+under [/games](/games) so the front page can stay simple and fast.
+
+This *Thoughts* section is a tiny Markdown blog. To add a post, drop a new file in
+`posts/` and rebuild. Delete this one whenever you like.

--- a/scripts/preview.mjs
+++ b/scripts/preview.mjs
@@ -1,0 +1,46 @@
+// Local static server for the built `dist/` directory.
+// Emulates GitHub Pages: missing paths fall back to /404.html with a 404 status,
+// so the /games SPA deep-link redirect can be tested locally.
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+const port = Number(process.env.PORT) || 4178;
+
+const types = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain',
+  '.woff2': 'font/woff2',
+};
+
+http
+  .createServer((req, res) => {
+    const urlPath = decodeURIComponent(req.url.split('?')[0]);
+    let file = path.join(root, urlPath);
+    try {
+      if (fs.existsSync(file) && fs.statSync(file).isDirectory()) {
+        file = path.join(file, 'index.html');
+      }
+      if (fs.existsSync(file) && fs.statSync(file).isFile()) {
+        res.writeHead(200, { 'content-type': types[path.extname(file)] || 'application/octet-stream' });
+        return res.end(fs.readFileSync(file));
+      }
+    } catch {
+      /* fall through to 404 */
+    }
+    res.writeHead(404, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(fs.readFileSync(path.join(root, '404.html')));
+  })
+  .listen(port, () => {
+    console.log(`Serving dist/ at http://localhost:${port}`);
+  });

--- a/src/post.html
+++ b/src/post.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{TITLE_TAG}}</title>
+    <meta name="description" content="{{DESCRIPTION}}" />
+    <link rel="canonical" href="{{CANONICAL}}" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="{{OG_TITLE}}" />
+    <meta property="og:description" content="{{DESCRIPTION}}" />
+    <meta property="og:url" content="{{CANONICAL}}" />
+    {{SOCIAL}}
+    <style>
+{{STYLES}}
+    </style>
+  </head>
+  <body>
+    {{NAV}}
+    <main class="post">
+      <article class="post-article">
+        {{COVER}}
+        <header class="post-header">
+          <p class="post-kicker"><a href="{{THOUGHTS_HREF}}">Thoughts</a></p>
+          <h1 class="post-title">{{TITLE}}</h1>
+          <p class="post-meta"><time datetime="{{DATE_ISO}}">{{DATE_HUMAN}}</time>{{TAGS}}</p>
+        </header>
+        <div class="post-body">
+{{CONTENT}}
+        </div>
+        <footer class="post-footer">
+          <a href="{{THOUGHTS_HREF}}">&larr; All thoughts</a>
+        </footer>
+      </article>
+    </main>
+    {{SCRIPTS}}
+  </body>
+</html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,732 @@
+:root {
+  --ink: #1f2328;
+  --muted: #5b6570;
+  --faint: #8a929c;
+  --accent: #2f5d8a;
+  --rule: #e4e8ee;
+  --bg: #ffffff;
+  --maxw: 50rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  background: #f4f6f9;
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.cv {
+  max-width: var(--maxw);
+  margin: 2.5rem auto;
+  padding: 3rem 3.25rem;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04), 0 8px 24px rgba(16, 24, 40, 0.06);
+}
+
+/* Header */
+.cv-header {
+  margin-bottom: 1.5rem;
+}
+
+.cv-name {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
+}
+
+.cv-title {
+  margin: 0.35rem 0 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.01em;
+}
+
+.cv-tagline {
+  margin: 0.5rem 0 0;
+  max-width: 42rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.cv-contact {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.25rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.cv-contact li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.cv-contact .ico {
+  color: var(--accent);
+  flex: none;
+}
+
+.cv-contact a,
+.cv-email a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.cv-contact a:hover,
+.cv-email a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Body */
+.cv-body h2 {
+  margin: 1.6rem 0 0.75rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--rule);
+  color: var(--accent);
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cv-body h3 {
+  margin: 1rem 0 0.1rem;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+}
+
+.cv-body h4 {
+  margin: 0.7rem 0 0.1rem;
+  font-size: 0.9rem;
+  font-weight: 650;
+  color: var(--ink);
+}
+
+/* Entry headings carry the title on the left and the date on the right. */
+.cv-body h3.entry,
+.cv-body h4.entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.cv-body .entry-title {
+  min-width: 0;
+}
+
+.cv-body .entry-date {
+  flex: none;
+  font-weight: 500;
+  color: var(--faint);
+  font-size: 0.82rem;
+  letter-spacing: 0.01em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.cv-body h4.entry .entry-date {
+  font-size: 0.8rem;
+}
+
+.cv-body p {
+  margin: 0.35rem 0;
+  font-size: 0.9rem;
+}
+
+.cv-body p.meta {
+  margin: 0.1rem 0 0.4rem;
+  color: var(--faint);
+  font-size: 0.82rem;
+  font-style: normal;
+  letter-spacing: 0.01em;
+}
+
+.cv-body ul {
+  margin: 0.3rem 0 0.6rem;
+  padding-left: 1.15rem;
+}
+
+.cv-body li {
+  margin: 0.22rem 0;
+  font-size: 0.9rem;
+  line-height: 1.46;
+}
+
+.cv-body li::marker {
+  color: var(--accent);
+}
+
+.cv-body strong {
+  font-weight: 650;
+}
+
+.cv-body a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(47, 93, 138, 0.45);
+}
+
+.cv-body a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.cv-body em {
+  font-style: italic;
+}
+
+/* The Summary paragraph sits right under the header with no h2. */
+.cv-body > p:first-child {
+  margin-top: 0;
+  font-size: 0.95rem;
+  color: #2c333b;
+}
+
+@media (max-width: 640px) {
+  .cv {
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 1.75rem 1.4rem;
+  }
+  .cv-name {
+    font-size: 1.6rem;
+  }
+}
+
+/* Print: one tight page, identical look, no browser chrome. */
+@page {
+  size: Letter;
+  margin: 0.32in 0.45in;
+}
+
+@media print {
+  body {
+    background: #fff;
+    font-size: 8.4pt;
+  }
+  .cv {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+  .cv-name {
+    font-size: 16.5pt;
+  }
+  .cv-title {
+    font-size: 9.6pt;
+    margin-top: 0.1rem;
+  }
+  .cv-tagline {
+    font-size: 8.4pt;
+    margin-top: 0.15rem;
+  }
+  .cv-contact {
+    font-size: 7.8pt;
+    margin-top: 0.35rem;
+    gap: 0.2rem 1rem;
+  }
+  .cv-header {
+    margin-bottom: 0.34rem;
+  }
+  .cv-body > p:first-child {
+    font-size: 8.5pt;
+  }
+  .cv-body h2 {
+    margin: 0.34rem 0 0.2rem;
+    padding-bottom: 0.16rem;
+    font-size: 8.8pt;
+    letter-spacing: 0.05em;
+  }
+  .cv-body h3 {
+    margin: 0.32rem 0 0;
+    font-size: 9.3pt;
+  }
+  .cv-body h4 {
+    margin: 0.24rem 0 0;
+    font-size: 8.8pt;
+  }
+  .cv-body h3.entry .entry-date {
+    font-size: 7.8pt;
+  }
+  .cv-body h4.entry .entry-date {
+    font-size: 7.6pt;
+  }
+  .cv-body p,
+  .cv-body li {
+    font-size: 8.4pt;
+  }
+  .cv-body p {
+    margin: 0.13rem 0;
+  }
+  .cv-body p.meta {
+    font-size: 7.7pt;
+    margin: 0.02rem 0 0.16rem;
+  }
+  .cv-body ul {
+    margin: 0.08rem 0 0.16rem;
+    padding-left: 1rem;
+  }
+  .cv-body li {
+    margin: 0.05rem 0;
+    line-height: 1.22;
+  }
+  a {
+    color: var(--accent) !important;
+    border-bottom: none !important;
+  }
+  .cv-body a {
+    color: inherit !important;
+    border-bottom: 1px solid rgba(47, 93, 138, 0.5) !important;
+  }
+  h2,
+  h3,
+  h4 {
+    break-after: avoid;
+    page-break-after: avoid;
+  }
+  li,
+  p,
+  h3 + p.meta {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  :root {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}
+
+/* ===== Site nav ===== */
+.site-nav {
+  background: transparent;
+}
+
+.site-nav-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 1.4rem 3.25rem 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.site-nav-brand {
+  font-weight: 700;
+  font-size: 0.98rem;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.site-nav-brand:hover {
+  color: var(--accent);
+}
+
+.site-nav-links {
+  display: flex;
+  gap: 1.2rem;
+  font-size: 0.9rem;
+  margin-left: auto;
+}
+
+.site-nav-links a {
+  color: var(--muted);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.site-nav-links a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.site-nav-links a[aria-current="page"] {
+  color: var(--ink);
+  border-bottom-color: var(--accent);
+}
+
+/* ===== Post + Thoughts cards ===== */
+.post,
+.thoughts {
+  max-width: var(--maxw);
+  margin: 1.5rem auto 3rem;
+  padding: 3rem 3.25rem;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04), 0 8px 24px rgba(16, 24, 40, 0.06);
+}
+
+/* ===== Post header ===== */
+.post-header {
+  margin-bottom: 1.8rem;
+  padding-bottom: 1.2rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.post-kicker {
+  margin: 0 0 0.7rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+}
+
+.post-kicker a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.post-title {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.post-meta {
+  margin: 0.8rem 0 0;
+  color: var(--faint);
+  font-size: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.7rem;
+}
+
+.post-meta time {
+  color: var(--muted);
+}
+
+.post-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag {
+  background: #eef2f7;
+  color: var(--muted);
+  font-size: 0.72rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  letter-spacing: 0.01em;
+}
+
+/* ===== Post cover (hero) ===== */
+.post-cover {
+  margin: -3rem -3.25rem 1.8rem;
+}
+
+.post-cover img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 10px 10px 0 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+/* ===== Post body ===== */
+.post-body {
+  color: #2a3038;
+}
+
+.post-body > p:first-child {
+  margin-top: 0;
+  font-size: 1.12rem;
+  line-height: 1.65;
+  color: #2a3038;
+}
+
+.post-body p {
+  margin: 1.05rem 0;
+  font-size: 1.02rem;
+  line-height: 1.72;
+}
+
+.post-body h2 {
+  margin: 2.4rem 0 0.8rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid var(--rule);
+  font-size: 1.4rem;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.post-body h3 {
+  margin: 1.9rem 0 0.6rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+}
+
+.post-body ul,
+.post-body ol {
+  margin: 1rem 0;
+  padding-left: 1.35rem;
+}
+
+.post-body li {
+  margin: 0.45rem 0;
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+.post-body li::marker {
+  color: var(--accent);
+}
+
+.post-body a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(47, 93, 138, 0.3);
+}
+
+.post-body a:hover {
+  border-bottom-color: var(--accent);
+}
+
+.post-body strong {
+  font-weight: 650;
+}
+
+.post-body em {
+  font-style: italic;
+}
+
+.post-body blockquote {
+  margin: 1.5rem 0;
+  padding: 0.6rem 1.1rem;
+  border-left: 3px solid var(--accent);
+  background: #f7f9fb;
+  border-radius: 0 6px 6px 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.post-body blockquote p {
+  margin: 0.3rem 0;
+  font-size: 0.95rem;
+}
+
+.post-body code {
+  background: #f0f2f5;
+  padding: 0.12em 0.36em;
+  border-radius: 4px;
+  font-size: 0.88em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.post-body pre {
+  margin: 1.4rem 0;
+  padding: 1rem 1.1rem;
+  background: #f6f8fa;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.post-body pre code {
+  background: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+.post-body img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+/* Tables */
+.post-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.6rem 0;
+  font-size: 0.9rem;
+}
+
+.post-body th,
+.post-body td {
+  padding: 0.55rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--rule);
+}
+
+.post-body thead th {
+  border-bottom: 2px solid var(--rule);
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.post-body tbody td:first-child {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+/* Mermaid diagrams */
+.post-body pre.mermaid {
+  background: #fafbfc;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  padding: 1.2rem;
+  text-align: center;
+  overflow-x: auto;
+}
+
+.post-body pre.mermaid:not([data-processed="true"]) {
+  visibility: hidden;
+  min-height: 3rem;
+}
+
+.post-body pre.mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Post footer */
+.post-footer {
+  margin-top: 2.6rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid var(--rule);
+  font-size: 0.9rem;
+}
+
+.post-footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+/* ===== Thoughts list ===== */
+.post-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.post-list-item {
+  padding: 1.4rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.post-list-item:last-child {
+  border-bottom: none;
+}
+
+.post-list-date {
+  margin: 0 0 0.3rem;
+  color: var(--faint);
+  font-size: 0.82rem;
+}
+
+.post-list-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+.post-list-title a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+.post-list-title a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.post-list-summary {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.post-list-tags {
+  margin: 0.6rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+@media (max-width: 640px) {
+  .site-nav-inner {
+    padding: 1.1rem 1.4rem 0;
+  }
+  .post,
+  .thoughts {
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 1.75rem 1.4rem;
+  }
+  .post-cover {
+    margin: -1.75rem -1.4rem 1.4rem;
+  }
+  .post-cover img {
+    border-radius: 0;
+    border-bottom: none;
+  }
+  .post-title {
+    font-size: 1.55rem;
+  }
+  .post-body p,
+  .post-body li {
+    font-size: 0.98rem;
+  }
+  .post-body table {
+    font-size: 0.82rem;
+  }
+}
+
+@media print {
+  .site-nav,
+  .post-footer,
+  .post-kicker {
+    display: none;
+  }
+}

--- a/src/template.html
+++ b/src/template.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{TITLE_TAG}}</title>
+    <meta name="description" content="{{DESCRIPTION}}" />
+    <style>
+{{STYLES}}
+    </style>
+  </head>
+  <body>
+    {{NAV}}
+    <main class="cv">
+      <header class="cv-header">
+        <h1 class="cv-name">{{NAME}}</h1>
+        <p class="cv-title">{{TITLE}}</p>
+        <p class="cv-tagline">{{TAGLINE}}</p>
+        <ul class="cv-contact">
+      {{CONTACT}}
+        </ul>
+      </header>
+      <div class="cv-body">
+{{CONTENT}}
+      </div>
+    </main>
+    {{SCRIPTS}}
+  </body>
+</html>

--- a/src/thoughts.html
+++ b/src/thoughts.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{TITLE_TAG}}</title>
+    <meta name="description" content="{{DESCRIPTION}}" />
+    <style>
+{{STYLES}}
+    </style>
+  </head>
+  <body>
+    {{NAV}}
+    <main class="thoughts">
+      <ul class="post-list">
+{{LIST}}
+      </ul>
+    </main>
+  </body>
+</html>

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -2,6 +2,7 @@
   "name": "web-ui",
   "version": "0.1.0",
   "private": true,
+  "homepage": "/games",
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",

--- a/web-ui/public/404.html
+++ b/web-ui/public/404.html
@@ -22,7 +22,7 @@
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
       // Otherwise, leave pathSegmentsToKeep as 0.
-      var pathSegmentsToKeep = 0;
+      var pathSegmentsToKeep = 1;
 
       var l = window.location;
       l.replace(

--- a/web-ui/src/index.tsx
+++ b/web-ui/src/index.tsx
@@ -19,46 +19,49 @@ import { CssBaseline } from "@mui/material";
 import { HomePage } from "./Home/HomePage";
 import { PuzzleTimePage } from "./PuzzleTime/PuzzleTimePage";
 
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <Layout />,
-    children: [
-      {
-        path: "/",
-        element: <HomePage />,
-      },
-      {
-        path: "/Profile",
-        element: <Profile />,
-      },
-      {
-        path: "/Crossword",
-        element: <Crossword />,
-      },
-      {
-        path: "/FivePM",
-        element: <FivePM />,
-      },
-      {
-        path: "/Posts",
-        element: <MarkdownHost />,
-      },
-      {
-        path: "/WordGuessGame",
-        element: <WordGuessPage />,
-      },
-      {
-        path: "/MultiplayerGames",
-        element: <LobbyPage />,
-      },
-      {
-        path: "/PuzzleTime",
-        element: <PuzzleTimePage />,
-      },
-    ],
-  },
-]);
+const router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      element: <Layout />,
+      children: [
+        {
+          path: "/",
+          element: <HomePage />,
+        },
+        {
+          path: "/Profile",
+          element: <Profile />,
+        },
+        {
+          path: "/Crossword",
+          element: <Crossword />,
+        },
+        {
+          path: "/FivePM",
+          element: <FivePM />,
+        },
+        {
+          path: "/Posts",
+          element: <MarkdownHost />,
+        },
+        {
+          path: "/WordGuessGame",
+          element: <WordGuessPage />,
+        },
+        {
+          path: "/MultiplayerGames",
+          element: <LobbyPage />,
+        },
+        {
+          path: "/PuzzleTime",
+          element: <PuzzleTimePage />,
+        },
+      ],
+    },
+  ],
+  { basename: "/games" }
+);
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement


### PR DESCRIPTION
Replace the React/MUI home page with an ofek.io-style setup: a single cv.md source compiled by build.mjs into a self-contained, print-friendly dist/. The existing React games are untouched and served under /games/.

- build.mjs: markdown -> dist/ generator (CV + Thoughts blog), copies the built games into dist/games/, and writes an SPA-aware root 404.html so /games deep links round-trip on GitHub Pages.
- cv.md: CV content (experience, projects, skills, education, press).
- src/: print CSS + HTML shells; posts/: starter Thoughts post; CNAME.
- scripts/preview.mjs: local server emulating GitHub Pages 404 behaviour.
- web-ui: configure for the /games subpath only (homepage, router basename, 404 pathSegmentsToKeep) -- no game logic changed.
- .github/workflows/deploy.yml: build games + CV and publish dist/ to Pages.
- README: document the new build/preview/deploy flow.